### PR TITLE
Support prepending randomtemp to a call, similar to ccache

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ export RANDOMTEMP_EXECUTABLE=nvcc
 # you may notice that the generated temp directories are used
 ```
 
+As an alternative to `RANDOMTEMP_EXECUTABLE`, you can also can pass the executable as the first argument
+```bash
+./randomtemp.exe nvcc -v -ccbin "/usr/bin/gcc-5" "test.cpp"
+```
+
 ## Environment variables
 - RANDOMTEMP_EXECUTABLE: target executable to be patched (Optional, default: name of the current executable)
 - RANDOMTEMP_BASEDIR: directory to store temporary files (Optional, default: current working directory)

--- a/src/main.rs
+++ b/src/main.rs
@@ -491,14 +491,30 @@ mod tests {
         let expect_env = call_env();
         let d = get_current_dir().ok();
         d.and_then(|p| {
-            let new_env = process::Command::new("randomtemp")
-                .env_remove("RANDOMTEMP_EXECUTABLE")
-                .env_remove("RANDOMTEMP_BASEDIR")
-                .env_remove("RANDOMTEMP_MAXTRIAL")
-                .arg(ENV_COMMAND)
-                .current_dir(p)
-                .output()
-                .expect("failed to execute process");
+            // set on windows is a builtin and does not exist on the
+            // path so isn't a valid executable, so call via a shell
+            let new_env = if cfg!(windows) {
+                process::Command::new("randomtemp")
+                    .env_remove("RANDOMTEMP_EXECUTABLE")
+                    .env_remove("RANDOMTEMP_BASEDIR")
+                    .env_remove("RANDOMTEMP_MAXTRIAL")
+                    .arg("cmd")
+                    .arg("/q")
+                    .arg("/c")
+                    .arg(ENV_COMMAND)
+                    .current_dir(p)
+                    .output()
+                    .expect("failed to execute process")
+            } else {
+                process::Command::new("randomtemp")
+                    .env_remove("RANDOMTEMP_EXECUTABLE")
+                    .env_remove("RANDOMTEMP_BASEDIR")
+                    .env_remove("RANDOMTEMP_MAXTRIAL")
+                    .arg(ENV_COMMAND)
+                    .current_dir(p)
+                    .output()
+                    .expect("failed to execute process")
+            };
 
             let new_output = new_env.stdout;
             let new_error = new_env.stderr;

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,14 +36,14 @@ fn is_absolute_path(path: &str) -> bool {
     Path::new(path).is_absolute()
 }
 
-fn find_executable_in_path_by_name(p: &PathBuf, cp: &PathBuf) -> Option<PathBuf> {
-    let f = get_file_name(Some(p));
+fn find_executable_in_path_by_name(p: &Path, cp: &Path) -> Option<PathBuf> {
+    let f = p.file_name();
     f.and_then(|s| {
         which(s)
             .ok()
             // TODO: We should try to find another one instead of
             // skipping.
-            .and_then(|np| if &np == cp { None } else { Some(np) })
+            .and_then(|np| if np == cp { None } else { Some(np) })
     })
 }
 
@@ -98,11 +98,6 @@ fn get_current_dir() -> Result<String, String> {
         .to_str()
         .ok_or("Cannot convert the current working directory to a UTF-8 string")?;
     Ok(String::from(p))
-}
-
-fn get_file_name(pbopt: Option<&PathBuf>) -> Option<&OsStr> {
-    let pb = pbopt?;
-    pb.file_name()
 }
 
 fn get_file_stem(pbopt: Option<&PathBuf>) -> Option<&OsStr> {


### PR DESCRIPTION
Some versions of CMake use the nvcc path to find the cuda toolkit, so using randomtemp to spoof the compiler will not work. With this PR you can give CMake the real `nvcc` but use `CMAKE_CUDA_COMPILER_LAUNCHER` to prepend `randomtemp` to the command line when compiling, just as you can do with `ccache`.

Related to pytorch/pytorch#62445